### PR TITLE
GDG Cloud Hanoi website based on aura template

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Awesome! Contributions of all kinds are greatly appreciated. To help smoothen th
 | GDG Craiova | [View Now](https://gdgcraiova.dev/) |
 | GDG Houston | [View Now](https://gdghoustontx.org/) |
 | GDG Cloud Ahmedabad | [View Now](https://gdgahmedabad.cloud/) |
-
+| GDG Cloud Hanoi | [View Now](https://gdgcloudhanoi.com/) |
 
 
 Project is published under the [MIT license](/LICENSE.md).  


### PR DESCRIPTION
Adding GDG Cloud Hanoi (Vietnam) to the list of websites built with the aura template.