### PR TITLE
aura: Fix Facebook icon not showing up on Teams page

### DIFF
--- a/src/components/common/SocialInfo.vue
+++ b/src/components/common/SocialInfo.vue
@@ -13,7 +13,17 @@
         >
           <v-icon small :color="this.$vuetify.theme.dark == true?'white':'#333'">mdi-twitter</v-icon>
         </v-btn>
-
+        <v-btn
+          aria-label="social media btn"
+          small
+          class="ml-0 mt-0 mx-0"
+          icon
+          v-if="checkExistance(data.facebook,0)"
+          :href="data.facebook"
+          target="_blank"
+        >
+          <v-icon small :color="this.$vuetify.theme.dark == true?'white':'#333'">mdi-facebook</v-icon>
+        </v-btn>
         <v-btn
           aria-label="social media btn"
           small


### PR DESCRIPTION
Facebook icon was not visible due to the missing code. Added the required code in SocialInfo.vue