### PR TITLE
Short Name Implementation

### DIFF
--- a/src/components/contact/ContactHeader.vue
+++ b/src/components/contact/ContactHeader.vue
@@ -3,7 +3,7 @@
         <v-row align="center" class="py-0 my-0">
             <v-col md="12" sm="12" cols="12" class="py-0 my-0">
                 <p class="google-font mb-0" style="font-weight: 350;font-size:200%"><b>
-                    <span style="color: #1a73e8;">Contact</span></b> {{data.name}}
+                    <span style="color: #1a73e8;">Contact</span></b> {{data.shortName || data.name}}
                 </p>
             </v-col>
         </v-row>

--- a/src/components/core/Footer.vue
+++ b/src/components/core/Footer.vue
@@ -53,7 +53,7 @@
         <v-col cols="12" md="10" lg="10" sm="11" class="px-0 mx-0"> 
           <v-divider></v-divider>
           <v-toolbar text class="pa-0 px-0 mt-3 mx-0 elevation-0" style="padding:0 !important" :class="this.$vuetify.theme.dark == true?'grey darken-4':'white'">
-            <v-toolbar-title class="google-font pl-0 ml-0 mr-3" style="font-size:200%">{{config.generalConfig.name || ''}}</v-toolbar-title>
+            <v-toolbar-title class="google-font pl-0 ml-0 mr-3" style="font-size:200%">{{config.generalConfig.shortName || config.generalConfig.name || ''}}</v-toolbar-title>
             <v-btn
                 v-for="(item,i) in config.footerConfig['Footer End Session Link']" 
                 :key="i"

--- a/src/components/core/Toolbar.vue
+++ b/src/components/core/Toolbar.vue
@@ -30,7 +30,7 @@
         style="text-decoration:none;font-size:110%"
         :class="this.$vuetify.theme.dark?'whiteText':'blackText'"
       >
-      {{config.generalConfig.name || ""}}</router-link>
+      {{config.generalConfig.shortName || config.generalConfig.name || ""}}</router-link>
     </v-toolbar-title>
     <v-spacer></v-spacer>
 

--- a/src/components/home/AboutCommunity.vue
+++ b/src/components/home/AboutCommunity.vue
@@ -23,7 +23,7 @@
               to="/about"
               class="google-font"
               style="text-decoration:none;color:white"
-            >See More about {{config.generalConfig.name}}</router-link>
+            >See More about {{config.generalConfig.shortName || config.generalConfig.name}}</router-link>
           </div>
         </div>
       </v-col>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -34,7 +34,7 @@
       <v-row justify="center" align="center" class="py-5">
         <v-col md="11" lg="10" sm="11" xs="12" class="py-0 mb-5">
           <coc :data="coc" />
-          <antiHarassmentPolicy :data="config.generalConfig.name" />
+          <antiHarassmentPolicy :data="config.generalConfig.shortName || config.generalConfig.name" />
         </v-col>
       </v-row>
     </v-container>


### PR DESCRIPTION
Implementation as per aura admin pull request [#57](https://github.com/gdg-x/aura-admin/pull/57) (formerly #52).
This allows short names to be used when required, giving better UI/UX. Long names clutter the interface and are quite a hassle to read.

If there are no short names defined, the long (original) name will be used instead.